### PR TITLE
Add 'All Time' Period Selection to view all gains tracked easily

### DIFF
--- a/app/src/app/players/[username]/gained/page.tsx
+++ b/app/src/app/players/[username]/gained/page.tsx
@@ -214,7 +214,7 @@ function BucketedDailyGainsPanel(props: BucketedDailyGainsPanelProps) {
             const minDate =
               "period" in timeRange
                 ? new Date(Date.now() - PeriodProps[timeRange.period].milliseconds)
-                : timeRange.startDate;
+                : data.find((d) => d.date > timeRange.startDate)?.date || timeRange.startDate;
 
             const maxDate = "period" in timeRange ? new Date() : timeRange.endDate;
 

--- a/app/src/components/players/PlayerGainedChart.tsx
+++ b/app/src/components/players/PlayerGainedChart.tsx
@@ -49,11 +49,11 @@ export async function PlayerGainedChart(props: PlayerGainedChartProps) {
   const isShowingRanks = view === "ranks";
 
   const { name, measure } = MetricProps[metric];
-
+      
   const minDate =
-    "period" in timeRange
-      ? new Date(Date.now() - PeriodProps[timeRange.period].milliseconds)
-      : timeRange.startDate;
+  "period" in timeRange
+    ? new Date(Date.now() - PeriodProps[timeRange.period].milliseconds)
+    : data.find((d) => d.date > timeRange.startDate)?.date || timeRange.startDate;
 
   const maxDate = "period" in timeRange ? new Date() : timeRange.endDate;
 
@@ -73,7 +73,7 @@ export async function PlayerGainedChart(props: PlayerGainedChartProps) {
       maxDate={maxDate}
       xAxisLabelFormatter={(timestamp) => {
         // If the timespan is under 3 days long, show hours and minutes too
-        if (maxDate.getTime() - minDate.getTime() < 1000 * 60 * 60 * 24 * 3) {
+        if (maxDate.getTime() - (minDate).getTime() < 1000 * 60 * 60 * 24 * 3) {
           return formatDatetime(new Date(timestamp), {
             day: "numeric",
             month: "short",

--- a/app/src/components/players/PlayerGainedTable.tsx
+++ b/app/src/components/players/PlayerGainedTable.tsx
@@ -43,6 +43,8 @@ interface PlayerGainedTableProps {
   timeRange: TimeRangeFilter;
 }
 
+var isAllTime = false;
+
 export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProps>) {
   const { player, gains, metric, timeRange, children } = props;
 
@@ -77,16 +79,20 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
     const nextParams = new URLSearchParams(searchParams);
 
     if (newPeriod === "custom") {
+      isAllTime = false;
       nextParams.set("dialog", "custom_period");
     } else if (newPeriod == "alltime") {
+      isAllTime = true;
       nextParams.delete("period");
       nextParams.set("startDate", player.registeredAt.toISOString());
       nextParams.set("endDate", player.updatedAt ? player.updatedAt.toISOString() : new Date().toISOString());
     } else if (newPeriod === Period.WEEK) {
+      isAllTime = false;
       nextParams.delete("period");
       nextParams.delete("startDate");
       nextParams.delete("endDate");
     } else {
+      isAllTime = false;
       nextParams.set("period", newPeriod);
       nextParams.delete("startDate");
       nextParams.delete("endDate");
@@ -106,20 +112,36 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
                 {player.displayName}&apos;s gains in the last&nbsp;
                 <span className="text-white">{PeriodProps[timeRange.period].name.toLowerCase()}</span>
               </>
-            ) : (
-              <>
-                {player.displayName}&apos;s gains during:&nbsp;
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-white underline">custom period</span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Start: {formatDatetime(timeRange.startDate)}
-                    <br />
-                    End: {formatDatetime(timeRange.endDate)}
-                  </TooltipContent>
-                </Tooltip>
-              </>
+            ) : ( isAllTime ? (
+                <>
+                  {player.displayName}&apos;s&nbsp;
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="text-white underline">all time</span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Start: {formatDatetime(timeRange.startDate)}
+                      <br />
+                      End: {formatDatetime(timeRange.endDate)}
+                    </TooltipContent>
+                  </Tooltip>
+                  &nbsp;gains
+                </>
+              ) : (
+                <>
+                  {player.displayName}&apos;s gains during:&nbsp;
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="text-white underline">custom period</span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Start: {formatDatetime(timeRange.startDate)}
+                      <br />
+                      End: {formatDatetime(timeRange.endDate)}
+                    </TooltipContent>
+                  </Tooltip>
+                </>
+              )
             )}
           </p>
         </div>
@@ -458,6 +480,7 @@ function PeriodSelect(props: PeriodSelectProps) {
           if (val === undefined) {
             onPeriodSelected(Period.WEEK);
           } else if (isPeriod(val) || val === "custom" || val === "alltime") {
+            val == "alltime" ? (isAllTime = true) : (isAllTime = false);
             onPeriodSelected(val);
           }
         });
@@ -465,7 +488,7 @@ function PeriodSelect(props: PeriodSelectProps) {
     >
       <ComboboxButton className="w-full" isPending={isTransitioning}>
         <div className="flex items-center gap-x-2">
-          {period ? PeriodProps[period].name : "Custom period"}
+          {period ? PeriodProps[period].name : (isAllTime ? "All time" : "Custom period")}
         </div>
       </ComboboxButton>
       <ComboboxContent>

--- a/app/src/components/players/PlayerGainedTable.tsx
+++ b/app/src/components/players/PlayerGainedTable.tsx
@@ -84,7 +84,7 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
     } else if (newPeriod == "alltime") {
       isAllTime = true;
       nextParams.delete("period");
-      nextParams.set("startDate", player.registeredAt.toISOString());
+      nextParams.set("startDate", new Date("2013-01-01").toISOString());
       nextParams.set("endDate", player.updatedAt ? player.updatedAt.toISOString() : new Date().toISOString());
     } else if (newPeriod === Period.WEEK) {
       isAllTime = false;

--- a/app/src/components/players/PlayerGainedTable.tsx
+++ b/app/src/components/players/PlayerGainedTable.tsx
@@ -73,11 +73,15 @@ export function PlayerGainedTable(props: PropsWithChildren<PlayerGainedTableProp
     router.replace(`/players/${player.username}/gained?${nextParams.toString()}`, { scroll: false });
   }
 
-  function handlePeriodSelected(newPeriod: Period | "custom") {
+  function handlePeriodSelected(newPeriod: Period | "custom" | "alltime") {
     const nextParams = new URLSearchParams(searchParams);
 
     if (newPeriod === "custom") {
       nextParams.set("dialog", "custom_period");
+    } else if (newPeriod == "alltime") {
+      nextParams.delete("period");
+      nextParams.set("startDate", player.registeredAt.toISOString());
+      nextParams.set("endDate", player.updatedAt ? player.updatedAt.toISOString() : new Date().toISOString());
     } else if (newPeriod === Period.WEEK) {
       nextParams.delete("period");
       nextParams.delete("startDate");
@@ -438,7 +442,7 @@ function MetricTypeSelect(props: MetricTypeSelectProps) {
 
 interface PeriodSelectProps {
   period?: Period;
-  onPeriodSelected: (period: Period | "custom") => void;
+  onPeriodSelected: (period: Period | "custom" | "alltime") => void;
 }
 
 function PeriodSelect(props: PeriodSelectProps) {
@@ -453,7 +457,7 @@ function PeriodSelect(props: PeriodSelectProps) {
         startTransition(() => {
           if (val === undefined) {
             onPeriodSelected(Period.WEEK);
-          } else if (isPeriod(val) || val === "custom") {
+          } else if (isPeriod(val) || val === "custom" || val === "alltime") {
             onPeriodSelected(val);
           }
         });
@@ -472,6 +476,7 @@ function PeriodSelect(props: PeriodSelectProps) {
                 {PeriodProps[period].name}
               </ComboboxItem>
             ))}
+            <ComboboxItem value="alltime">All time</ComboboxItem>
             <ComboboxItem value="custom">Select custom period...</ComboboxItem>
           </ComboboxItemGroup>
         </ComboboxItemsContainer>


### PR DESCRIPTION
Currently, you can only view 'All Time' gains by manually finding and inputting your first snapshot date to the custom date selection.

This pull request updates the `PlayerGainedTable` and related components to introduce an "all time" period selection. 

* Added "all time" as a selectable period, setting `startDate` and `endDate` accordingly, and updated the `handlePeriodSelected` function to handle this new period.
* Updated the calculation of `minDate` to use the earliest date in the dataset that is greater than `timeRange.startDate`, if available.
* Introduced the `isAllTime` variable to track if the "all time" period is selected and updated the `PeriodSelect` component to display "All time" when selected.
* Modified the tooltip to display the start and end dates when the "all time" period is selected.